### PR TITLE
Upgrade GH action

### DIFF
--- a/.github/actions/presubmit-variant/action.yml
+++ b/.github/actions/presubmit-variant/action.yml
@@ -20,7 +20,7 @@ runs:
           echo ".github/" >> .melangeignore && tree -a . && \
           sudo rm -rf /work && sudo mkdir /work
 
-    - uses: chainguard-images/actions/apko-build@44e0af71f27d227e937fa07faccbebec700cac07
+    - uses: chainguard-images/actions/apko-build@865de1840519dea43c67c07db74da6ea00205e8a
       with:
         config: apko.yaml
         tag: quay.io/jetstack/${{ inputs.variant }}

--- a/.github/actions/release-variant/action.yml
+++ b/.github/actions/release-variant/action.yml
@@ -21,7 +21,7 @@ runs:
           echo ".github/" >> .melangeignore && tree -a . && \
           sudo rm -rf /work && sudo mkdir /work
 
-    - uses: chainguard-images/actions/apko-snapshot@44e0af71f27d227e937fa07faccbebec700cac07
+    - uses: chainguard-images/actions/apko-snapshot@865de1840519dea43c67c07db74da6ea00205e8a
       with:
         config: apko.yaml
         archs: aarch64,armhf,armv7,ppc64le,s390x,x86,x86_64


### PR DESCRIPTION
see https://github.com/chainguard-images/actions/pull/129

TODO: Ideally, we would also fix the tag of the apko image so the GH action does not break by it self.