### PR TITLE
Don't build images for arches we don't support

### DIFF
--- a/.github/actions/release-variant/action.yml
+++ b/.github/actions/release-variant/action.yml
@@ -24,7 +24,7 @@ runs:
     - uses: chainguard-images/actions/apko-snapshot@865de1840519dea43c67c07db74da6ea00205e8a
       with:
         config: apko.yaml
-        archs: aarch64,armhf,armv7,ppc64le,s390x,x86,x86_64
+        archs: aarch64,armv7,ppc64le,x86_64
         registry: quay.io
         base-tag: quay.io/jetstack/${{ inputs.variant }}
         generic-user: ${{ inputs.username }}


### PR DESCRIPTION
We're currently running builds for several architectures we don't support anywhere, see https://github.com/cert-manager/base-images/actions/runs/7535673184/job/20512001018#step:3:759