### PR TITLE
Upgrade Alpine from v3.19 to v3.21

### DIFF
--- a/base-static-csi/apko.yaml
+++ b/base-static-csi/apko.yaml
@@ -1,11 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/v3.19/main
-  keyring:
-    # apko fetches the keyring from https://alpinelinux.org/releases.json
-    # However, it seems like that site has a wrong entry for the ppc64le architecture.
-    # That is why we have to add an extra key here.
-    - https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
+    - https://dl-cdn.alpinelinux.org/alpine/v3.21/main
 
   packages:
     - tzdata

--- a/base-static/apko.yaml
+++ b/base-static/apko.yaml
@@ -1,11 +1,6 @@
 contents:
   repositories:
-    - https://dl-cdn.alpinelinux.org/alpine/v3.19/main
-  keyring:
-    # apko fetches the keyring from https://alpinelinux.org/releases.json
-    # However, it seems like that site has a wrong entry for the ppc64le architecture.
-    # That is why we have to add an extra key here.
-    - https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
+    - https://dl-cdn.alpinelinux.org/alpine/v3.21/main
 
   packages:
     - tzdata


### PR DESCRIPTION
See https://alpinelinux.org/releases/:
v3.19 will be EOL on 2025-11-01, while v3.21 will be EOL on 2026-11-01