### PR TITLE
Bump to ensure GHA keep running

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ and so there's a risk that this disablement will happen on this repo.
 
 As an initial low-tech solution to this problem, we have calendar reminders to create a PR for this repo at least every 60 days.
 
-<!-- Counter to bump for the low tech solution mentioned above: 3 -->
+<!-- Counter to bump for the low tech solution mentioned above: 4 -->


### PR DESCRIPTION
See [readme](https://github.com/cert-manager/base-images?tab=readme-ov-file#%EF%B8%8F-issue-with-scheduled-github-actions)