### PR TITLE
Readd keyring for ppc64le

### DIFF
--- a/base-static-csi/apko.yaml
+++ b/base-static-csi/apko.yaml
@@ -1,6 +1,11 @@
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/v3.21/main
+  keyring:
+    # apko fetches the keyring from https://alpinelinux.org/releases.json
+    # However, it seems like that site has a wrong entry for the ppc64le architecture.
+    # That is why we have to add an extra key here.
+    - https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
 
   packages:
     - tzdata

--- a/base-static/apko.yaml
+++ b/base-static/apko.yaml
@@ -1,6 +1,11 @@
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/v3.21/main
+  keyring:
+    # apko fetches the keyring from https://alpinelinux.org/releases.json
+    # However, it seems like that site has a wrong entry for the ppc64le architecture.
+    # That is why we have to add an extra key here.
+    - https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
 
   packages:
     - tzdata


### PR DESCRIPTION
In https://github.com/cert-manager/base-images/pull/13, we upgraded from v3.19 to v3.21.
I thought that that PR would fix the incorrect keyring for the ppc64le architecture in the https://alpinelinux.org/releases.json file, but the issue is still there. So, we have to keep the workaround.

This PR partially reverts the https://github.com/cert-manager/base-images/pull/13 PR and readds the keyring workaround.